### PR TITLE
fix: filter中でも矢印キーでセッション移動可能にする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- セッションフィルタ入力中に `↑/↓` キーで一覧選択を移動できない不具合を修正（Enter で pane 移動しなくてもカーソル移動可能）
+
 ## [0.1.2] - 2026-03-29
 
 ### Added

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -21,10 +21,10 @@ var (
 	upKeys   = key.NewBinding(key.WithKeys("k", "up"))
 	downKeys = key.NewBinding(key.WithKeys("j", "down"))
 
-	approveKey    = key.NewBinding(key.WithKeys("a"))
-	denyKey       = key.NewBinding(key.WithKeys("d"))
-	promptApprove = key.NewBinding(key.WithKeys("A"))
-	promptDeny    = key.NewBinding(key.WithKeys("D"))
+	approveKey     = key.NewBinding(key.WithKeys("a"))
+	denyKey        = key.NewBinding(key.WithKeys("d"))
+	promptApprove  = key.NewBinding(key.WithKeys("A"))
+	promptDeny     = key.NewBinding(key.WithKeys("D"))
 	autoApproveKey = key.NewBinding(key.WithKeys("t"))
 )
 
@@ -471,6 +471,10 @@ func (m Model) updateFilterInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.filtering = false
 		m.filterInput.Blur()
 		return m.handleEnter()
+	case msg.Type == tea.KeyUp:
+		return m.moveCursor(-1)
+	case msg.Type == tea.KeyDown:
+		return m.moveCursor(1)
 	}
 
 	var inputCmd tea.Cmd

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -1068,7 +1068,6 @@ func TestSimpleDenyOnWaitingClaude(t *testing.T) {
 	}
 }
 
-
 func TestApproveIgnoredOnNonWaitingState(t *testing.T) {
 	m, _, _, _, _ := newTestModel()
 	projects := []core.Project{
@@ -1332,7 +1331,6 @@ func TestCanInputOnClaudeSession(t *testing.T) {
 		t.Error("canInput() = false, want true for Claude session on right pane")
 	}
 }
-
 
 // TestCanInputFalseOnNonClaude verifies canInput returns false for Codex and Gemini sessions.
 func TestCanInputFalseOnNonClaude(t *testing.T) {
@@ -2005,6 +2003,64 @@ func TestFilterModeStartsWithSlash(t *testing.T) {
 	}
 	if m.filterQuery != "" {
 		t.Errorf("filterQuery = %q, want empty", m.filterQuery)
+	}
+}
+
+func TestFilterModeArrowKeysMoveCursor(t *testing.T) {
+	m, _, _, _, _ := newTestModel()
+	projects := []core.Project{
+		{
+			Path: "/project-a",
+			Name: "project-a",
+			Sessions: []*core.Session{
+				{PID: 100, State: core.Idle, Tool: core.ToolClaude, PaneID: "%1"},
+				{PID: 200, State: core.Idle, Tool: core.ToolCodex, PaneID: "%2"},
+				{PID: 300, State: core.Waiting, Tool: core.ToolClaude, PaneID: "%3"},
+			},
+		},
+	}
+	m = feedProjects(m, projects)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m = updated.(Model)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("idle")})
+	m = updated.(Model)
+
+	if got := visibleSessionCount(m.entries); got != 2 {
+		t.Fatalf("visible sessions = %d, want 2 for idle filter", got)
+	}
+	if pid := selectedPID(m); pid != 100 {
+		t.Fatalf("selected PID before down = %d, want 100", pid)
+	}
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(Model)
+	if pid := selectedPID(m); pid != 200 {
+		t.Fatalf("selected PID after down = %d, want 200", pid)
+	}
+	if !m.filtering {
+		t.Fatal("expected filtering=true after down in filter mode")
+	}
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = updated.(Model)
+	if pid := selectedPID(m); pid != 100 {
+		t.Fatalf("selected PID after up = %d, want 100", pid)
+	}
+}
+
+func TestFilterModeRuneKIsAcceptedAsInput(t *testing.T) {
+	m, _, _, _, _ := newTestModel()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m = updated.(Model)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("wor")})
+	m = updated.(Model)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	m = updated.(Model)
+
+	if got := m.filterInput.Value(); got != "work" {
+		t.Fatalf("filter input = %q, want work", got)
 	}
 }
 


### PR DESCRIPTION
## 概要
- filter入力中に↑/↓でセッション選択を移動できるよう修正
- 既存のj/k文字入力は維持（KeyUp/KeyDownのみ移動に割り当て）
- CHANGELOG.md の Unreleased に修正内容を追記

## 変更ファイル
- internal/tui/update.go
- internal/tui/update_test.go
- CHANGELOG.md

## テスト
- go test ./... -v
- go vet ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed arrow key (↑/↓) navigation in the session filter. Users can now move between filtered list items without pressing Enter first.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->