### PR TITLE
fix: detect Codex approval prompts while working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Codex が子プロセスありで Working 判定されている場合でも、承認選択肢UIを検出したら `Waiting` に補正するように修正
 - セッションフィルタ入力中に `↑/↓` キーで一覧選択を移動できない不具合を修正（Enter で pane 移動しなくてもカーソル移動可能）
 - 選択中セッションに留まっている間もプレビューが自動更新されるように修正（承認待ちなどペイン内容の変化が ScanInterval 以内に反映される。同一 pane の silent refresh 中は既存テキストを表示してちらつきを抑止）
 

--- a/internal/core/state.go
+++ b/internal/core/state.go
@@ -304,9 +304,9 @@ var claudeApprovalPattern = regexp.MustCompile(
 )
 
 // codexApprovalPattern は Codex CLI の承認プロンプトの構造を検出する正規表現。
-// 番号付き選択肢（"1. Yes..." + "2. Yes..." or "2. No..."）の連続で判定する。
+// 番号付き選択肢（"1. Yes..." / "1. Allow..." + "2. ..."）の連続で判定する。
 // 単独の "1. Yes" ではなく後続行も確認することで誤検知を防ぐ。
-var codexApprovalPattern = regexp.MustCompile(`(?m)^\s*[›>]?\s*1\.\s+Yes.*\n\s*[›>]?\s*2\.\s+`)
+var codexApprovalPattern = regexp.MustCompile(`(?im)^\s*[›>❯]?\s*1\.\s+(?:yes|allow)\b.*\n\s*[›>❯]?\s*2\.\s+`)
 
 // geminiIdlePattern は Gemini CLI の入力待ちプロンプトを検出する正規表現。
 // Gemini はアイドル時にステータスバーに "workspace" と "sandbox" を表示する。
@@ -314,10 +314,10 @@ var codexApprovalPattern = regexp.MustCompile(`(?m)^\s*[›>]?\s*1\.\s+Yes.*\n\s
 var geminiIdlePattern = regexp.MustCompile(`(?m)workspace\s+\(.+\)\s+.*sandbox`)
 
 // RefineToolUseState はペインテキストから状態を精緻化する。
-// - Claude: 全状態でペインテキストをチェック。classifyClaudePane が権威的ソース。
-//   判定できた場合はその状態を採用。判定不能かつ JSONL=Waiting → ToolUse に降格。
-// - Codex Idle → Waiting（承認待ち検出）
-// - Gemini Thinking → Waiting（承認待ち）または Idle（入力プロンプト検出）
+//   - Claude: 全状態でペインテキストをチェック。classifyClaudePane が権威的ソース。
+//     判定できた場合はその状態を採用。判定不能かつ JSONL=Waiting → ToolUse に降格。
+//   - Codex: プロセス由来の Thinking/Idle → Waiting（承認待ち検出）
+//   - Gemini Thinking → Waiting（承認待ち）または Idle（入力プロンプト検出）
 func (s *StateManager) RefineToolUseState(term terminal.Terminal) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -352,8 +352,8 @@ func (s *StateManager) RefineToolUseState(term terminal.Terminal) {
 			switch {
 			case sess.Tool == ToolClaude && sess.PaneID != "":
 				// Claude: 全状態でペインテキストをチェック
-			case sess.State == Idle && sess.Tool == ToolCodex:
-				// Codex: 子プロセスなし(Idle) → 承認待ちかもしれない
+			case sess.Tool == ToolCodex:
+				// Codex: 子プロセス有無で Thinking/Idle 判定後、承認待ちなら Waiting に上書きする
 			case sess.State == Thinking && sess.Tool == ToolGemini:
 				// Gemini: 子プロセス検査不可 → ペインテキストで状態判定
 			default:

--- a/internal/core/state_test.go
+++ b/internal/core/state_test.go
@@ -592,6 +592,83 @@ func (m *paneTextTerminal) SendKeys(paneID string, keys ...string) error { retur
 func (m *paneTextTerminal) IsAvailable() bool                            { return true }
 func (m *paneTextTerminal) Name() string                                 { return "mock" }
 
+func TestRefineCodexThinkingToWaiting(t *testing.T) {
+	// Codex が子プロセスありで Thinking 判定されても、承認UIがあれば Waiting に補正されることを確認する。
+	manager := NewStateManager(nil)
+	manager.projects = []Project{
+		{
+			Name: "proj",
+			Path: "/project",
+			Sessions: []*Session{
+				{PID: 100, Tool: ToolCodex, State: Thinking, PaneID: "%1", WorkingDir: "/project"},
+			},
+		},
+	}
+	manager.summary = calcSummary(manager.projects)
+
+	term := &paneTextTerminal{
+		texts: map[string]string{
+			"%1": "Run this command?\n› 1. Yes, allow once\n  2. No, tell Codex what to do differently\n",
+		},
+	}
+
+	manager.RefineToolUseState(term)
+
+	projects := manager.Projects()
+	if len(projects) != 1 || len(projects[0].Sessions) != 1 {
+		t.Fatalf("unexpected projects/sessions: %v", projects)
+	}
+	if got := projects[0].Sessions[0].State; got != Waiting {
+		t.Errorf("state = %v, want Waiting (codex approval prompt detected from Thinking)", got)
+	}
+	if got := manager.Summary().Waiting; got != 1 {
+		t.Errorf("summary.Waiting = %d, want 1", got)
+	}
+}
+
+func TestCodexApprovalPatternVariants(t *testing.T) {
+	// Codex の選択肢UIがプロンプト記号や文言の差分を含んでも検出できることを確認する。
+	tests := []struct {
+		name      string
+		input     string
+		wantMatch bool
+	}{
+		{
+			name:      "current yes choice",
+			input:     "Apply changes?\n› 1. Yes, apply all changes\n  2. No, discard changes\n",
+			wantMatch: true,
+		},
+		{
+			name:      "heavy prompt symbol",
+			input:     "Run command?\n❯ 1. Yes, allow once\n  2. No\n",
+			wantMatch: true,
+		},
+		{
+			name:      "allow first choice",
+			input:     "Approve command?\n  1. Allow once\n  2. Deny\n",
+			wantMatch: true,
+		},
+		{
+			name:      "single choice only",
+			input:     "1. Yes, proceed\n",
+			wantMatch: false,
+		},
+		{
+			name:      "unrelated numbered list",
+			input:     "1. Install dependencies\n2. Run tests\n",
+			wantMatch: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := codexApprovalPattern.MatchString(tc.input); got != tc.wantMatch {
+				t.Errorf("codexApprovalPattern.MatchString(%q) = %v, want %v", tc.input, got, tc.wantMatch)
+			}
+		})
+	}
+}
+
 func TestRefineGeminiThinkingToWaiting(t *testing.T) {
 	// Gemini の Thinking 状態がペインテキストの承認パターンで Waiting に変わることを確認する。
 	manager := NewStateManager(nil)
@@ -741,7 +818,6 @@ func TestRefineGeminiWaitingPriority(t *testing.T) {
 		t.Errorf("state = %v, want Waiting (approval prompt takes priority over idle status bar)", got)
 	}
 }
-
 
 func TestContainsApprovalPrompt(t *testing.T) {
 	// containsApprovalPrompt が claudeApprovalPattern の正規表現で正しく動作することを確認する。

--- a/internal/e2e/pipeline_test.go
+++ b/internal/e2e/pipeline_test.go
@@ -361,7 +361,7 @@ func TestPipelineGemini_RefineToWaiting(t *testing.T) {
 	}
 }
 
-// TestPipelineCodex_RefineToWaiting tests that Codex Idle → Waiting
+// TestPipelineCodex_RefineToWaiting tests that Codex Thinking → Waiting
 // when pane text contains the numbered approval pattern.
 func TestPipelineCodex_RefineToWaiting(t *testing.T) {
 	term := &mockTerminal{
@@ -377,8 +377,8 @@ func TestPipelineCodex_RefineToWaiting(t *testing.T) {
 		map[string]string{
 			"ttys001": psLine(2001, 500, "codex", "codex --full-auto"),
 		},
-		nil, // no children → Idle
-		nil,
+		map[int]string{2001: "3001\n"},
+		map[int]string{3001: "bash"},
 	))
 
 	scanner := core.NewDefaultScanner(term, ps)


### PR DESCRIPTION
## Summary

- Codex セッションの状態精緻化で、子プロセスありの Working/Thinking 状態でも承認選択肢UIを検出したら `Waiting` に補正
- Codex 承認選択肢の検出パターンを `›` / `❯` / `>` と `Yes` / `Allow` 系の表記に対応
- Codex が Working 判定中に Waiting へ補正される回帰テストと E2E テストを追加

## Testing

- [x] テスト実施済み
  - `go test ./... -v`
  - `go vet ./...`
- [ ] 未実施（理由を記載）

## Release Note

- ユーザー向け変更点: Codex が承認待ちUIを表示しているのに Working と表示され、Baton から承認できない問題を修正
- `CHANGELOG.md` 更新: `Unreleased` に追記済み

## Checklist

- [x] PR タイトルが GitHub Release にそのまま載っても読める
- [x] 適切なラベルを付けた (`bug`)
- [x] ユーザー向け変更がある場合は `CHANGELOG.md` の `Unreleased` を更新した


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex session state detection so approval prompts now switch the UI to **Waiting** even when the session is initially marked **Working** or **Thinking**.
  * Made approval prompt recognition more reliable across different prompt layouts and wording variants, reducing false detections.
  * Added broader validation to ensure Codex approval flows transition correctly in end-to-end scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->